### PR TITLE
Add SIXEL display option to ImageViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Use the `vimg` CLI command to quickly view an image in the terminal.
 vimg <path_to_image>
 ```
 
+Pass `--sixel` to use SIXEL graphics if your terminal supports it.
+
 Click and drag (or press W/S/A/D) to move around the image, and scroll (or press -/+) to zoom in/out of the image.
 
 `vimg` is built on `ImageView`, a [Rich](https://github.com/textualize/rich/) renderable that renders images with padding/zoom, and `ImageViewer`, a [Textual](https://github.com/textualize/textual/) widget that adds mouse interactivity to `ImageView`. Add `textual-imageview` as a dependency to use them in your Textual app!

--- a/textual_imageview/app.py
+++ b/textual_imageview/app.py
@@ -35,7 +35,7 @@ class ImageViewerApp(App):
         Binding("Q,_", "zoom(2)", "Fast Zoom Out", show=False),
     ]
 
-    def __init__(self, image_path: Union[str, Path]):
+    def __init__(self, image_path: Union[str, Path], *, use_sixel: bool = False):
         """Inits vimg
 
         Args:
@@ -49,7 +49,7 @@ class ImageViewerApp(App):
 
         self.sub_title = image_path.name
         self.image = Image.open(image_path)
-        self.image_viewer = ImageViewer(self.image)
+        self.image_viewer = ImageViewer(self.image, use_sixel=use_sixel)
 
     def action_move(self, delta_x: int, delta_y: int):
         self.image_viewer.image.move(delta_x, delta_y)
@@ -79,7 +79,13 @@ def vimg():
         version=__version__,
     )
 
+    parser.add_argument(
+        "--sixel",
+        action="store_true",
+        help="Render image using SIXEL graphics if supported",
+    )
+
     args = parser.parse_args()
 
-    app = ImageViewerApp(args.image_path)
+    app = ImageViewerApp(args.image_path, use_sixel=args.sixel)
     app.run()

--- a/textual_imageview/img.py
+++ b/textual_imageview/img.py
@@ -263,7 +263,7 @@ class ImageView:
             pad_left = " " * max(-origin_x, 0)
             pad_top = "\n" * max(-origin_y // 2, 0)
 
-            return [Segment(pad_top + pad_left + sixel, Style.null())]
+            return [Segment.control(pad_top + pad_left + sixel)]
 
         null_style = Style.null()
         newline = Segment("\n", null_style)

--- a/textual_imageview/img.py
+++ b/textual_imageview/img.py
@@ -36,9 +36,11 @@ class ImageView:
         zoom: int = 0,
         origin_position: Tuple[int, int] = (0, 0),
         container_size: Optional[Tuple[int, int]] = None,
+        use_sixel: bool = False,
     ):
         self.images: dict[Zoom, Image.Image] = {}
         self.segment_cache: dict[Zoom, dict[Tuple[int, int], Segment]] = {}
+        self.use_sixel = use_sixel
 
         self.image = image
         self._container_size = container_size
@@ -245,6 +247,24 @@ class ImageView:
         w, h = self._container_size[0], self._container_size[1] * 2
         origin_x, origin_y = self.origin_position
 
+        if self.use_sixel:
+            # Crop the visible region
+            x0 = max(origin_x, 0)
+            y0 = max(origin_y, 0)
+            x1 = min(origin_x + w, img_w)
+            y1 = min(origin_y + h, img_h)
+
+            if x0 >= x1 or y0 >= y1:
+                return ""
+
+            cropped = image.crop((x0, y0, x1, y1))
+            sixel = self.image_to_sixel(cropped)
+
+            pad_left = " " * max(-origin_x, 0)
+            pad_top = "\n" * max(-origin_y // 2, 0)
+
+            return [Segment(pad_top + pad_left + sixel, Style.null())]
+
         null_style = Style.null()
         newline = Segment("\n", null_style)
 
@@ -312,3 +332,54 @@ class ImageView:
             cache[position] = segment
 
         return cache[position]
+
+    def image_to_sixel(self, image: Image.Image) -> str:
+        """Return a SIXEL escape sequence representing ``image``.
+
+        This is a minimal implementation that supports a limited palette but
+        works well enough for simple images. It does not attempt any dithering
+        or compression optimisations.
+        """
+        image = image.convert("RGB")
+        width, height = image.size
+
+        palette: dict[tuple[int, int, int], int] = {}
+        registers: list[str] = []
+
+        def get_register(color: tuple[int, int, int]) -> int:
+            if color not in palette:
+                index = len(palette)
+                palette[color] = index
+                r, g, b = color
+                registers.append(
+                    f"#{index};2;{r*100//255};{g*100//255};{b*100//255}"
+                )
+            return palette[color]
+
+        pixels = image.load()
+
+        # Build palette
+        for y in range(height):
+            for x in range(width):
+                get_register(pixels[x, y])
+
+        lines: list[str] = ["\x1bPq" + "".join(registers)]
+
+        for y0 in range(0, height, 6):
+            for color, reg in palette.items():
+                line = [f"#{reg}"]
+                for x in range(width):
+                    bits = 0
+                    for dy in range(6):
+                        y = y0 + dy
+                        if y >= height:
+                            continue
+                        if pixels[x, y] == color:
+                            bits |= 1 << dy
+                    line.append(chr(0x3F + bits))
+                line.append("$")
+                lines.append("".join(line))
+            lines.append("-")
+
+        lines.append("\x1b\\")
+        return "".join(lines)

--- a/textual_imageview/img.py
+++ b/textual_imageview/img.py
@@ -263,7 +263,7 @@ class ImageView:
             pad_left = " " * max(-origin_x, 0)
             pad_top = "\n" * max(-origin_y // 2, 0)
 
-            return [Segment.control(pad_top + pad_left + sixel)]
+            return [Segment("", None, pad_top + pad_left + sixel)]
 
         null_style = Style.null()
         newline = Segment("\n", null_style)

--- a/textual_imageview/img.py
+++ b/textual_imageview/img.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 from PIL import Image
 from rich.color import Color
 from rich.console import Console, ConsoleOptions, RenderResult
-from rich.segment import Segment
+from rich.segment import Segment, ControlType
 from rich.style import Style
 
 Zoom = int
@@ -263,7 +263,13 @@ class ImageView:
             pad_left = " " * max(-origin_x, 0)
             pad_top = "\n" * max(-origin_y // 2, 0)
 
-            return [Segment("", None, pad_top + pad_left + sixel)]
+            return [
+                Segment(
+                    pad_top + pad_left + sixel,
+                    None,
+                    ((ControlType.CURSOR_UP,),),
+                )
+            ]
 
         null_style = Style.null()
         newline = Segment("\n", null_style)

--- a/textual_imageview/viewer.py
+++ b/textual_imageview/viewer.py
@@ -16,14 +16,14 @@ class ImageViewer(Widget):
     }
     """
 
-    def __init__(self, image: Image.Image):
+    def __init__(self, image: Image.Image, *, use_sixel: bool = False):
         super().__init__()
         if not isinstance(image, Image.Image):
             raise TypeError(
                 f"Expected PIL Image, but received '{type(image).__name__}' instead."
             )
 
-        self.image = ImageView(image)
+        self.image = ImageView(image, use_sixel=use_sixel)
         self.mouse_down = False
 
     def on_show(self):


### PR DESCRIPTION
## Summary
- enable SIXEL rendering via a new `use_sixel` flag
- add `--sixel` CLI option and pass through to widget
- document SIXEL usage in README

## Testing
- `python -m compileall -q textual_imageview`

------
https://chatgpt.com/codex/tasks/task_e_68695aa1da2c832186e4c31dd216482e